### PR TITLE
Fix multifox script download link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@
   
   ![](https://i.imgur.com/BE7oPcu.png)
 
-  [Download link](https://raw.githubusercontent.com/xiaoxiaoflood/firefox-scripts/master/chrome/minMaxCloseButton.uc.js).
+  [Download link](https://raw.githubusercontent.com/xiaoxiaoflood/firefox-scripts/master/chrome/multifoxContainer.uc.js).
 </details>
 <details>
   <summary>Open in Unloaded Tab</summary>


### PR DESCRIPTION
The link to download the multifox script currently goes to the script for MinMaxClose. I changed it so that it will go to the multifox file. Sorry if I did something wrong, I don't have much experience with github.