### PR TITLE
Add script to restore browser.newtab.url in about:config

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,15 @@
   [Download link](https://raw.githubusercontent.com/xiaoxiaoflood/firefox-scripts/master/chrome/contextToSearch.uc.js).
 </details>
 
+<details>
+ <summary>Restore <code>browser.newtab.url</code> Pref to <code>about:config</code> (by TheRealPSV)</summary>
+ This script restores the <code>browser.newtab.url</code> preference to <code>about:config</code>. Using this preference, you can set whatever you like as your New Tab page, including things like <code>file://</code> URLs that don't work with new tab override extensions. Once you install the script, just set the preference in <code>about:config</code> and it should work automatically. Make sure you don't have any other new tab extensions, or it might not work.
+ 
+ (Written by [TheRealPSV](https://github.com/TheRealPSV))
+
+  [Download link](https://raw.githubusercontent.com/xiaoxiaoflood/firefox-scripts/master/chrome/newtab-aboutconfig.uc.js).
+</details>
+
 Bonus: I don't like the new password manager and the old one was removed in Fx 77. I'm still using it. If you want it too, save [these files](https://github.com/xiaoxiaoflood/firefox-scripts/tree/master/chrome/utils/passwordmgr), so that you can access the old password manager using chrome://userchromejs/content/passwordmgr/passwordManager.xhtml (bookmark this URL).
 
 ## Screenshots

--- a/chrome/newtab-aboutconfig.uc.js
+++ b/chrome/newtab-aboutconfig.uc.js
@@ -1,0 +1,44 @@
+// ==UserScript==
+// @name            Restore browser.newtab.url in about:config
+// @author          TheRealPSV
+// @include         main
+// @shutdown        UC.NewTabAboutConfig.destroy();
+// @onlyonce
+// ==/UserScript==
+
+const { AboutNewTab } = ChromeUtils.import(
+  "resource:///modules/AboutNewTab.jsm"
+);
+
+UC.NewTabAboutConfig = {
+  NEW_TAB_CONFIG_PATH: "browser.newtab.url",
+  init: function () {
+    //fetch pref if it exists
+    this.newTabURL = xPref.get(this.NEW_TAB_CONFIG_PATH);
+
+    //if pref doesn't exist, give it a default value of about:blank
+    if (!this.newTabURL) {
+      this.newTabURL = "about:blank";
+      xPref.set(this.NEW_TAB_CONFIG_PATH, this.newTabURL);
+    }
+
+    //set the new tab URL in the browser itself, and add a listener to update it when the config is changed
+    try {
+      AboutNewTab.newTabURL = this.newTabURL;
+      this.prefListener = xPref.addListener(
+        this.NEW_TAB_CONFIG_PATH,
+        (value) => {
+          AboutNewTab.newTabURL = value;
+        }
+      );
+    } catch (e) {
+      console.error(e);
+    } // Browser Console
+  },
+
+  destroy: function () {
+    xPref.removeListener(this.NEW_TAB_CONFIG_PATH);
+  },
+};
+
+UC.NewTabAboutConfig.init();


### PR DESCRIPTION
I use a local file as a homepage and Firefox doesn't usually allow local files as new tab pages. I wrote a script to restore the old config functionality, wanted to share it (thanks for this userscript framework by the way, it's extremely useful).

This allows a user to set a preference in about:config for their new tab page (like what Firefox used to do way back in the day), which can be any URL they choose, including local file:// URLs.